### PR TITLE
Fix SASS not reloading eleventy css on file change

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -14,6 +14,7 @@ const eleventyConfig = config => {
   config.addPassthroughCopy('./public/')
   config.addPassthroughCopy('./node_modules/bootstrap/dist/')
   config.addDataExtension('yml', contents => yaml.load(contents))
+  config.addWatchTarget('./styles/')
   return {
     dir: {
       input: 'content',


### PR DESCRIPTION
This makes Eleventy watch the styles folder and refreshes the CSS changes. Before, changing the SASS files would require restarting the server to see the changes.

Please make note if you experience any hot reloading issues in the future.