### PR TITLE
Fix font not being used properly

### DIFF
--- a/styles/abstracts/mixins.scss
+++ b/styles/abstracts/mixins.scss
@@ -4,56 +4,48 @@
 Application fonts.
  */
 @mixin subheading-regular {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 20px;
   line-height: 32px;
 }
 
 @mixin subheading-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 20px;
   line-height: 32px;
 }
 
 @mixin subheading-medium-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 24px;
   line-height: 29px;
 }
 
 @mixin subheading-medium-regular {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 24px;
   line-height: 29px;
 }
 
 @mixin h1-small-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 39px;
   line-height: 47px;
 }
 
 @mixin h1-small-semi-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 39px;
   line-height: 47px;
 }
 
 @mixin h1-semi-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 48px;
   line-height: 56px;
 }
 
 @mixin h1-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 48px;
   line-height: 56px;
@@ -61,7 +53,6 @@ Application fonts.
 
 // The small font above each of the sections' header (refer to home page)
 @mixin h1-section {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 14px;
   line-height: 17px;
@@ -69,98 +60,84 @@ Application fonts.
 }
 
 @mixin h2-semi-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 39px;
   line-height: 47px;
 }
 
 @mixin h3-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 31px;
   line-height: 38px;
 }
 
 @mixin h3-semi-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 31px;
   line-height: 38px;
 }
 
 @mixin h4-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 25px;
   line-height: 32px;
 }
 
 @mixin h4-semi-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 25px;
   line-height: 32px;
 }
 
 @mixin h5-semi-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 20px;
   line-height: 26px;
 }
 
 @mixin p1-regular {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 14px;
   line-height: 20px;
 }
 
 @mixin p2-regular {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
 }
 
 @mixin p3-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 18px;
   line-height: 28px;
 }
 
 @mixin p3-regular {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 18px;
   line-height: 28px;
 }
 
 @mixin nav-semi-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 20px;
   line-height: 32px;
 }
 
 @mixin p-footer {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 16px;
   line-height: 18px;
 }
 
 @mixin p-footer-bold {
-  font-family: "Inter", sans-serif;
   font-weight: 700;
   font-size: 16px;
   line-height: 18px;
 }
 
 @mixin caption-regular-uppercase {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 12px;
   line-height: 14px;
@@ -168,7 +145,6 @@ Application fonts.
 }
 
 @mixin caption-footer {
-  font-family: "Inter", sans-serif;
   font-weight: 400;
   font-size: 14px;
   line-height: 18px;
@@ -176,7 +152,6 @@ Application fonts.
 }
 
 @mixin button-regular {
-  font-family: "Inter", sans-serif;
   font-weight: 600;
   font-size: 0.9em;
   line-height: 18px;


### PR DESCRIPTION
Defining the font family in the mixins.scss causes the app to use the arial font instead.