### PR TITLE
Fix alternative button hover bugs

### DIFF
--- a/styles/base/animations.scss
+++ b/styles/base/animations.scss
@@ -1,19 +1,32 @@
 @import "../abstracts/variables";
 
 @mixin dark-button-transition {
-    transition: background-color 0.3s, color 0.3s;
+  transition: background-color 0.3s, color 0.3s;
 
-    &:hover {
-        background-color: $secondary-500;
-        color: $neutral-900;
-    }
+  &:hover {
+    background-color: $secondary-500;
+    color: $neutral-900;
+  }
 }
 
 @mixin light-button-transition {
-    transition: padding 0.3s, margin 0.3s;
+  &::before {
+    content: "";
+    transition: top, right, bottom, left, 0.3s ease-in-out;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border: $secondary-500 5px solid;
+    border-radius: 6px;
+  }
 
-    &:hover {
-        padding: 19px 27px;
-        margin: -3px;
-    }
+  &:hover::before,
+  &:focus::before {
+    top: -4px;
+    right: -4px;
+    bottom: -4px;
+    left: -4px;
+  }
 }

--- a/styles/pages/home.scss
+++ b/styles/pages/home.scss
@@ -42,7 +42,7 @@ Home page layout
 
   @media (max-width: $screen-md) {
     width: auto;
-    padding: 96px 40px 0px 40px;
+    padding: 96px 40px 60px 40px;
     justify-content: flex-start;
     padding-top: 30%;
   }
@@ -103,7 +103,8 @@ Home page layout
   /* alternative colors */
   background-color: $secondary-500;
   color: $neutral-900;
-  
+  position: relative;
+
   @include light-button-transition;
 }
 


### PR DESCRIPTION
On the mobile sizes (under 400px), hovered yellow button:
1) Shifts following layout down;
2) Make an impact to another button size.

On the home page for example:

**Before**
<img width="317" alt="before" src="https://github.com/code4sac/opensac.org/assets/40894913/38afbf2a-5562-4e0a-95f1-1aadfc1f843f">

**After**
<img width="318" alt="after" src="https://github.com/code4sac/opensac.org/assets/40894913/1396511f-8928-4bf4-b63d-8a303024ff3e">

Also some bottom padding for the first homepage block with buttons has been added.


**Before**
<img width="355" alt="before1" src="https://github.com/code4sac/opensac.org/assets/40894913/02b0f763-c50c-4f61-8511-e229081a461f">

**After**
<img width="318" alt="after2" src="https://github.com/code4sac/opensac.org/assets/40894913/9c3b4bff-05bf-4d2c-b3d9-79553c74774f">
