### PR TITLE
Single Project Error Handling

### DIFF
--- a/src/app/projects/[project]/singleProjectsRoadmap.jsx
+++ b/src/app/projects/[project]/singleProjectsRoadmap.jsx
@@ -9,15 +9,31 @@ export default function SingleProjectsRoadmap({ sectionType, data }) {
         <div className="project-info-container-alt">
           <div>
             <p className="project-info-label">Research</p>
-            <p className = "project-info-alt">{data.meta.roadmap.research.time_range}</p>
+            <p className = "project-info-alt">{
+            (()=> {if(data.meta.roadmap.research)
+                    return data.meta.roadmap.research.time_range;
+                  else
+                    return null;})()}</p>
             <p className="project-info-label">Design</p>
-            <p className = "project-info-alt">{data.meta.roadmap.design.time_range}</p>
+            <p className = "project-info-alt">{(()=> {if(data.meta.roadmap.design)
+                    return data.meta.roadmap.design.time_range;
+                  else
+                    return null;})()}</p>
             <p className="project-info-label">Development</p>
-            <p className = "project-info-alt">{data.meta.roadmap.development.time_range}</p>
+            <p className = "project-info-alt">{(()=> {if(data.meta.roadmap.development)
+                    return data.meta.roadmap.development.time_range;
+                  else
+                    return null;})()}</p>
             <p className="project-info-label">Deployment</p>
-            <p className = "project-info-alt">{data.meta.roadmap.deployment.time_range}</p>
+            <p className = "project-info-alt">{(()=> {if(data.meta.roadmap.deployment)
+                    return data.meta.roadmap.deployment.time_range;
+                  else
+                    return null;})()}</p>
             <p className="project-info-label">Launch</p>
-            <p className = "project-info-alt">{data.meta.roadmap.launch.time_range}</p>
+            <p className = "project-info-alt">{(()=> {if(data.meta.roadmap.launch)
+                    return data.meta.roadmap.launch.time_range;
+                  else
+                    return null;})()}</p>
           </div>
           <div>
             <h4 className="project-info-label">Objective</h4>


### PR DESCRIPTION
Added check for null meta.yml fields in roadmap to avoid errors for projects which are not in development but have a different meta.yml format. Currently, https://[opensac.org/projects/openbudgetsac.org(https://opensac.org/projects/openbudgetsac.org) shows a black screen due to the following error: 
![image](https://github.com/code4sac/opensac.org/assets/103269824/0be647ce-ff38-45ce-8be7-76fd9dc9c94c)
