### PR TITLE
Fix local development font 

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -3,7 +3,10 @@ import AppNavbar from '@/components/AppNavbar'
 import {Inter} from 'next/font/google'
 import '../../styles/main.scss'
 
-const inter = Inter({subsets: ['latin']})
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+})
 
 export const metadata = {
   title: 'Open Sacramento',

--- a/styles/base/typography.scss
+++ b/styles/base/typography.scss
@@ -1,14 +1,8 @@
-@charset "UTF-8";
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=Sacramento&display=swap");
 @import "../abstracts/mixins";
 
 /*
-Application typography
+Application typography. The Inter font family is applied by next/font in layout.js.
  */
-
-* {
-  font-family: "Inter", "Arial", sans-serif;
-}
 
 .paragraph-bold {
   @include subheading-bold;


### PR DESCRIPTION
I think I found a bug where local development displays the fallback font, Arial, instead of Inter. This only affects localhost, not the live site at opensac.org.

I found the following error in my Chrome dev console. 

> An @import rule was ignored because it wasn't defined at the top of the stylesheet. Such rules must appear at the top, before any style declaration and any other at-rule with the exception of @charset and @layer.

Error at _next/static/css/app/layout.css:95
```css
/*!**************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************!*\
  !*** css ./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[12].oneOf[2].use[1]!./node_modules/next/dist/build/webpack/loaders/next-font-loader/index.js??ruleSet[1].rules[12].oneOf[2].use[2]!./node_modules/next/font/google/target.css?{"path":"src\\app\\layout.js","import":"Inter","arguments":[{"subsets":["latin"],"display":"swap"}],"variableName":"inter"} ***!
  \**************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************/
/* cyrillic-ext */
@font-face {
  font-family: '__Inter_aaf875';
  font-style: normal;
  font-weight: 100 900;
  font-display: swap;
  src: url(/_next/static/media/ec159349637c90ad-s.woff2) format('woff2');
  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
}
/* cyrillic */
/* [...] */
/*!****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************!*\
  !*** css ./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[12].oneOf[13].use[2]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[12].oneOf[13].use[3]!./node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[12].oneOf[13].use[4]!./node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[12].oneOf[13].use[5]!./styles/main.scss ***!
  \****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************/
@charset "UTF-8";
/*
Application color theme.
 */
/* 
Screen breakpoints.
*/
/* 
Layout variables.
*/
/*
Application color theme.
 */
/* 
Screen breakpoints.
*/
/* 
Layout variables.
*/
/*
Base layout styles for all pages. Includes the app theme. This file should be imported in the base layout file.
 */
/* Error here. */
@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=Sacramento&display=swap");
* {
  box-sizing: border-box;
  padding: 0;
  margin: 0;
}
```
According to the [documentation](https://nextjs.org/docs/app/building-your-application/optimizing/fonts), we should use next/font. We already did this in layout.jsx, so we imported the font twice by doing it with CSS import. The error had to do with a chunk of code that Next.js was generating before `@import url(https://fonts.googleapis.com/...)`.

-  Updated the font code in layout.jsx to include the swap attribute. [Swap](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#description) uses the fallback font until the custom font has been loaded.
- Remove CSS import and charset from [typography.scss](https://github.com/code4sac/opensac.org/blob/main/styles/base/typography.scss), which resolves the error.